### PR TITLE
Report correct version for SRPM with multiple subpackages

### DIFF
--- a/mdapi/services/__init__.py
+++ b/mdapi/services/__init__.py
@@ -77,6 +77,15 @@ async def _get_package(brch, name=None, actn=None, srcn=None):
                 async with dtbsobjc.execute(GET_PACKAGE_BY_SRC, ("%s-%%" % srcn,)) as dbcursor:
                     pkgc = await dbcursor.fetchall()
                 if pkgc:
+                    for pkgx in pkgc:
+                        # Try to match the package with the source name at first
+                        if pkgx[2] == srcn:
+                            pckg = Packages(*pkgx)
+                            break
+
+                    if pckg:
+                        break
+
                     srcn = re.escape(srcn)
                     ptrn = re.compile("%s-[0-9]" % srcn)
                     for pkgx in pkgc:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -84,6 +84,21 @@ async def test_view_pkg_srcpkg_rawhide(testing_application):
         json.loads(await respobjc.text())
 
 
+async def test_view_pkg_srcpkg_rawhide_subpackage_version(testing_application):
+    if not databases_presence("rawhide"):
+        pytest.xfail(reason="Databases for 'rawhide' repositories are not available locally")
+    else:
+        respobjc = await testing_application.get("/rawhide/pkg/ruby")
+        assert respobjc.status == 200
+        pkgversion = json.loads(await respobjc.text())["version"]
+
+        respobjc = await testing_application.get("/rawhide/srcpkg/ruby")
+        assert respobjc.status == 200
+        srcversion = json.loads(await respobjc.text())["version"]
+
+        assert pkgversion == srcversion
+
+
 async def test_view_changelog_rawhide(testing_application):
     if not databases_presence("rawhide"):
         pytest.xfail(reason="Databases for 'rawhide' repositories are not available locally")


### PR DESCRIPTION
If there is multiple subpackages from single SRPM, the first subpackage is taken. This is fine as long as the subpackages are reusing the main package versioning, which might not always be the case.

To avoid issue, from the list of subpackages, try to select first the package which matches the source package name.

Unfortunately, this still leaves room for issues, where there is no subpackage of the same name as SRPM and when the versioning of subpackages differs from the SRPM version.

Fixes #35