### PR TITLE
[WIP] Demonstrate wrong Node.js SRPM version.

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,15 +88,17 @@ async def test_view_pkg_srcpkg_rawhide_subpackage_version(testing_application):
     if not databases_presence("rawhide"):
         pytest.xfail(reason="Databases for 'rawhide' repositories are not available locally")
     else:
-        respobjc = await testing_application.get("/rawhide/pkg/ruby")
-        assert respobjc.status == 200
-        pkgversion = json.loads(await respobjc.text())["version"]
+        pkgs = ["ruby", "nodejs"]
+        for pkg in pkgs:
+            respobjc = await testing_application.get(f"/rawhide/pkg/{pkg}")
+            assert respobjc.status == 200
+            pkgversion = json.loads(await respobjc.text())["version"]
 
-        respobjc = await testing_application.get("/rawhide/srcpkg/ruby")
-        assert respobjc.status == 200
-        srcversion = json.loads(await respobjc.text())["version"]
+            respobjc = await testing_application.get(f"/rawhide/srcpkg/{pkg}")
+            assert respobjc.status == 200
+            srcversion = json.loads(await respobjc.text())["version"]
 
-        assert pkgversion == srcversion
+            assert pkgversion == srcversion
 
 
 async def test_view_changelog_rawhide(testing_application):


### PR DESCRIPTION
This is just attempt to update the test case to demonstrate issues with Node.js as mentioned in #58. Not sure how to make better test case. Iterating over the whole DB content would probably be quite slow.