### PR TITLE
Step down from Fedora Linux 39 to Fedora Linux 38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:39
+FROM registry.fedoraproject.org/fedora:38
 
 LABEL maintainer "Akashdeep Dhar <t0xic0der@fedoraproject.org>"
 


### PR DESCRIPTION
The version of AIOHTTP required for the MDAPI v3.1.4 does not work on Python 3.12 which is the new default Python version for Fedora Linux 39.

More information can be found here https://stackoverflow.com/questions/74550830/error-could-not-build-wheels-for-aiohttp-which-is-required-to-install-pyprojec