### PR TITLE
Fix logging error while indexing

### DIFF
--- a/mdapi/database/main.py
+++ b/mdapi/database/main.py
@@ -242,7 +242,7 @@ def index_repositories():
         elif rels == "rawhide":
             versdata = "rawhide"
         urlx = f"{standard.DL_SERVER}/pub/fedora/linux/development/{versdata}/Everything/x86_64/os/repodata/"  # noqa : E501
-        servlogr.logrobjc.info(f"Acquired repo for {rels['koji_name']}/{versdata} of '{rels['status']}' branch at {urlx}")  # noqa : E501
+        servlogr.logrobjc.info(f"Acquired repo for {rels}/{versdata} branch at {urlx}")  # noqa : E501
         repolist.append((urlx, rels))
         urlx = urlx.replace("/x86_64/os/", "/source/tree/")
         repolist.append((urlx, f"src_{rels}"))


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

Discovered after the deployment was through.

```
[2024-09-04 05:22:36 +0000] [INFO] Branches metadata acquired.
Traceback (most recent call last):
  File "/usr/local/bin/mdapi", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/mdapi/main.py", line 59, in database
    index_repositories()
  File "/usr/local/lib/python3.12/site-packages/mdapi/database/main.py", line 241, in index_repositories
    servlogr.logrobjc.info(f"Acquired repo for {rels['koji_name']}/{versdata} of '{rels['status']}' branch at {urlx}")  # noqa : E501
                                                ~~~~^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```