### PR TITLE
Avoid skipping valid branches while indexing repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ EXPOSE 8080
 ENV PYTHONUNBUFFERED=1
 
 RUN dnf -y install python3-pip && dnf -y clean all
-RUN pip install --upgrade mdapi==3.1.6a5
+RUN pip install --upgrade mdapi==3.1.6a6
 
 # Uncomment the following MDAPI_CONFIG and comment the other MDAPI_CONFIG for local development builds
 # ENV MDAPI_CONFIG=/code/mdapi/confdata/standard.py

--- a/mdapi/database/main.py
+++ b/mdapi/database/main.py
@@ -271,8 +271,6 @@ def index_repositories():
 
     # Obtain the stable repos
     for rels in list_branches(status="current"):
-        if not re.search(r"f\d+", rels) or not re.search(r"epel\d+(?:\.\d+)?", rels) or not re.search(r"epel\d-next", rels):  # noqa : E501
-            continue
         versdata = re.search(r"\d+(?:\.\d+)?", rels).group()
         linklist, idenlist = [], []
 

--- a/mdapi/services/homepage.html
+++ b/mdapi/services/homepage.html
@@ -38,7 +38,7 @@ a:hover, a:link, a:visited, a:active {
                       |_|
 
 
-<a href="https://pypi.org/project/mdapi/3.1.6a5/">mdapi</a> is a small API exposing the metadata contained in different RPM
+<a href="https://pypi.org/project/mdapi/3.1.6a6/">mdapi</a> is a small API exposing the metadata contained in different RPM
 repositories.
 
 mdapi has access to the metadata of the different Fedora repositories and will

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mdapi"
-version = "3.1.6a5"
+version = "3.1.6a6"
 description = "A simple API for serving the metadata from the RPM repositories"
 authors = ["Pierre-Yves Chibon <pingou@pingoured.fr>", "Akashdeep Dhar <akashdeep.dhar@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
It looks like #296 introduced a subtle bug.  Previously the list_branches function returned more branches than were needed (despite the clt_status param), so we needed to skip invalid branches.  The skip condition accidentally always evaluated to true, so valid branches were being skipped too.  With the switch to querying bodhi for current branches, we only get valid branches.  That makes it so that the easiest fix is to just remove the skip condition.