### PR TITLE
Add support for Python 3.13 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: ["py38_download_needless", "py39_download_needless", "py310_download_needless", "py311_download_needless", "py312_download_needless", "py313_download_needless"]
+        tox-env: ["py38_download_needless", "py39_download_needless", "py310_download_needless", "py311_download_needless", "py312_download_needless", "py313_download_needless"] 
     runs-on: ubuntu-latest
     container: fedorapython/fedora-python-tox:latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: ["py38_download_required", "py39_download_required", "py310_download_required", "py311_download_required", "py312_download_required"]
+        tox-env: ["py38_download_required", "py39_download_required", "py310_download_required", "py311_download_required", "py312_download_required", "py313_download_required"]
     runs-on: ubuntu-latest
     container: fedorapython/fedora-python-tox:latest
     steps:
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: ["py38_download_needless", "py39_download_needless", "py310_download_needless", "py311_download_needless", "py312_download_needless"]
+        tox-env: ["py38_download_needless", "py39_download_needless", "py310_download_needless", "py311_download_needless", "py312_download_needless", "py313_download_needless"]
     runs-on: ubuntu-latest
     container: fedorapython/fedora-python-tox:latest
     steps:

--- a/forge.yaml
+++ b/forge.yaml
@@ -1,2 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/antinomyhq/forge/refs/heads/main/forge.schema.json
-model: anthropic/claude-3.7-sonnet

--- a/forge.yaml
+++ b/forge.yaml
@@ -1,0 +1,2 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/antinomyhq/forge/refs/heads/main/forge.schema.json
+model: anthropic/claude-3.7-sonnet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
 	"Operating System :: POSIX :: Linux",
 	"Topic :: Database",
 	"Topic :: Internet :: WWW/HTTP :: WSGI :: Application",

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ commands_pre =
     poetry install --all-extras
     mdapi --version 
 commands =
-    py{38,39,310,311,312}_download_required: pytest -vvv -o "addopts=--cov=mdapi --cov-report=term --cov-report=xml --cov-report=html" -m download_required tests/
-    py{38,39,310,311,312}_download_needless: pytest -vvv -o "addopts=--cov=mdapi --cov-report=term --cov-report=xml --cov-report=html" -m download_needless tests/
+    py{38,39,310,311,312,313}_download_required: pytest -vvv -o "addopts=--cov=mdapi --cov-report=term --cov-report=xml --cov-report=html" -m download_required tests/
+    py{38,39,310,311,312,313}_download_needless: pytest -vvv -o "addopts=--cov=mdapi --cov-report=term --cov-report=xml --cov-report=html" -m download_needless tests/
 
 [testenv:cleaning]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.8.0
-envlist = py{38,39,310,311,312}_{download_required,download_needless},cleaning
+envlist = py{38,39,310,311,312,313}_{download_required,download_needless},cleaning
 isolated_build = true
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Extended GitHub Actions CI matrix to include Python 3.13. All jobs pass successfully in fork.