### PR TITLE
Utilise commit hash to identify distinct deployments

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@ COPY . .
 
 ENV CGO_ENABLED=1 GOOS=linux
 
-RUN go mod download && go build -o meta
+RUN make
 
 FROM registry.fedoraproject.org/fedora-minimal:42 as runtime
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: make
 make:
 	@echo "Building binaries..."
-	@go build -x -o meta main.go
+	@COMMIT_HASH=$$(git rev-parse HEAD); \
+	go build -x -ldflags "-X metasource/metasource/config.COMMITHASH=$$COMMIT_HASH" -o meta main.go
 
 .PHONY: lint
 lint:
@@ -14,7 +15,7 @@ lint:
 	@$$(go env GOPATH)/bin/staticcheck ./...
 	@echo "Securing codebase..."
 	@go install github.com/securego/gosec/v2/cmd/gosec@latest
-	@$$(go env GOPATH)/bin/gosec -exclude-generated ./...
+	@$$(go env GOPATH)/bin/gosec -quiet -exclude-generated ./...
 
 .PHONY: test
 test:

--- a/metasource/config/base.go
+++ b/metasource/config/base.go
@@ -124,3 +124,5 @@ var PROTOCOL string = "https"
 var SERVNAME string = "MetaSource"
 
 var VERSDATA string = "v4.0.0"
+
+var COMMITHASH string = "0123456789abcdef" // To be replaced by latest commit hash

--- a/metasource/models/page.go
+++ b/metasource/models/page.go
@@ -24,6 +24,7 @@ type Page struct {
 	Vers string
 	Host string
 	Conn string
+	Hash string
 	Dict map[string]Vary
 	Park []Card
 }

--- a/metasource/routes/home.go
+++ b/metasource/routes/home.go
@@ -163,9 +163,10 @@ func RetrieveHome(w http.ResponseWriter, r *http.Request) {
 
 	data := models.Page{
 		Name: config.SERVNAME,
-		Vers: config.VERSDATA,
+		Vers: config.VERSDATA + "-" + config.COMMITHASH[0:8],
 		Host: config.HOSTNAME,
 		Conn: config.PROTOCOL,
+		Hash: config.COMMITHASH,
 		Dict: LastModified(list),
 		Park: park,
 	}

--- a/metasource/routes/shapes/home.html
+++ b/metasource/routes/shapes/home.html
@@ -13,7 +13,9 @@
     <a class="navbar-brand d-flex align-items-center flex-grow-1" href="#">
       <img src="/assets/fedora.svg" id="logo" class="logo" width="30" height="30">
     </a>
-    <span>{{ .Name }} {{ .Vers }}</span>
+    <span>
+      <a href="https://github.com/fedora-infra/mdapi/commits/{{ .Hash }}" target="_blank" class="text-decoration-none text-body">{{ .Name }} {{ .Vers }}</a>
+    </span>
   </div>
 </nav>
   <div class="container">


### PR DESCRIPTION
This PR adds commit hash tracking to deployment versions.

Key changes:
- Added commit hash injection during build process via linker flags
- Enhanced version display to show <version>-<commit-hash> format in UI along with clickable link that directs to GitHub
- Updated page model to include commit URL field for template rendering
- Simplified build process in while utilising it as an container application

<img width="1905" height="312" alt="Screenshot From 2025-08-17 22-34-36" src="https://github.com/user-attachments/assets/13161efd-b9a8-430d-b6cc-8dfcdf1f4e5b" />

Fixes: #382 