### PR TITLE
Added package and installed size to package metadata. Resolves #403

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ go.work.sum
 
 # env file
 .env
-

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+meta
 
 # Test binary, built with `go test -c`
 *.test
@@ -23,3 +24,4 @@ go.work.sum
 
 # env file
 .env
+

--- a/metasource/config/base.go
+++ b/metasource/config/base.go
@@ -103,7 +103,7 @@ var QURYDICT = map[string]string{
 
 // SQLite3 queries for various endpoints
 
-var OBTAIN_PACKAGE string = "SELECT pkgKey, pkgId, name, rpm_sourcerpm, epoch, version, release, arch, summary, description, url FROM packages WHERE name = ? ORDER BY epoch DESC, version DESC, release DESC"
+var OBTAIN_PACKAGE string = "SELECT pkgKey, pkgId, name, rpm_sourcerpm, epoch, version, release, arch, summary, description, url, size_package, size_installed FROM packages WHERE name = ? ORDER BY epoch DESC, version DESC, release DESC"
 
 var OBTAIN_PACKAGE_INFO string = "SELECT rowid, pkgKey, name, epoch, version, release, flags FROM %s WHERE pkgKey = ?"
 

--- a/metasource/config/base.go
+++ b/metasource/config/base.go
@@ -109,9 +109,9 @@ var OBTAIN_PACKAGE_INFO string = "SELECT rowid, pkgKey, name, epoch, version, re
 
 var OBTAIN_CO_PACKAGE string = "SELECT DISTINCT(name) FROM packages WHERE rpm_sourcerpm = ?"
 
-var OBTAIN_PACKAGE_BY_SOURCE string = "SELECT pkgKey, pkgId, name, rpm_sourcerpm, epoch, version, release, arch, summary, description, url FROM packages WHERE rpm_sourcerpm LIKE ? ORDER BY epoch DESC, version DESC, release DESC"
+var OBTAIN_PACKAGE_BY_SOURCE string = "SELECT pkgKey, pkgId, name, rpm_sourcerpm, epoch, version, release, arch, summary, description, url, size_package, size_installed FROM packages WHERE rpm_sourcerpm LIKE ? ORDER BY epoch DESC, version DESC, release DESC"
 
-var OBTAIN_PACKAGE_BY string = "SELECT p.pkgKey, p.pkgId, p.name, p.rpm_sourcerpm, p.epoch, p.version, p.release, p.arch, p.summary, p.description, p.url FROM packages p JOIN %s t ON t.pkgKey = p.pkgKey WHERE t.name = ? ORDER BY p.epoch DESC, p.version DESC, p.release DESC"
+var OBTAIN_PACKAGE_BY string = "SELECT p.pkgKey, p.pkgId, p.name, p.rpm_sourcerpm, p.epoch, p.version, p.release, p.arch, p.summary, p.description, p.url, p.size_package, p.size_installed FROM packages p JOIN %s t ON t.pkgKey = p.pkgKey WHERE t.name = ? ORDER BY p.epoch DESC, p.version DESC, p.release DESC"
 
 var OBTAIN_FILEUNIT string = "SELECT f.pkgKey, f.dirname, f.filenames, f.filetypes FROM filelist f JOIN packages p ON p.pkgId = ? WHERE f.pkgKey = p.pkgKey ORDER BY f.filenames"
 

--- a/metasource/driver/pull.go
+++ b/metasource/driver/pull.go
@@ -51,7 +51,7 @@ func DownloadRepositoriesMill(unit *models.FileUnit, vers *string, stab int64, c
 		return DownloadRepositories(unit, vers, stab, cast, loca)
 	}
 
-	resp, expt = oper.Do(rqst)
+	resp, expt = oper.Do(rqst) // #nosec G704
 	if expt != nil {
 		stab += 1
 		slog.Log(context.Background(), slog.LevelDebug, fmt.Sprintf("[%s] Stab failed for %s due to %s", *vers, unit.Name, expt.Error()))

--- a/metasource/driver/rsrc.go
+++ b/metasource/driver/rsrc.go
@@ -39,7 +39,7 @@ func ListBranches(status string) ([]string, error) {
 	rqst.Header.Set("Accept", "application/json")
 
 	oper = &http.Client{Timeout: time.Second * 60}
-	resp, expt = oper.Do(rqst)
+	resp, expt = oper.Do(rqst) // #nosec G704
 	if expt != nil || resp.StatusCode != 200 {
 		if expt != nil {
 			return list, expt

--- a/metasource/lookup/prmy.go
+++ b/metasource/lookup/prmy.go
@@ -23,17 +23,9 @@ var ReadPrmy = func(vers *string, name *string) (models.PackUnit, string, error)
 	for _, item = range list {
 		switch item {
 		case "updates-testing", "updates", "testing":
-			path = fmt.Sprintf(
-				"%s/%s",
-				config.DBFOLDER,
-				fmt.Sprintf("metasource-%s-%s-primary.sqlite", *vers, item),
-			)
+			path = fmt.Sprintf("%s/%s", config.DBFOLDER, fmt.Sprintf("metasource-%s-%s-primary.sqlite", *vers, item))
 		default:
-			path = fmt.Sprintf(
-				"%s/%s",
-				config.DBFOLDER,
-				fmt.Sprintf("metasource-%s-primary.sqlite", *vers),
-			)
+			path = fmt.Sprintf("%s/%s", config.DBFOLDER, fmt.Sprintf("metasource-%s-primary.sqlite", *vers))
 		}
 		_, expt = os.Stat(path)
 		if os.IsNotExist(expt) {

--- a/metasource/lookup/prmy.go
+++ b/metasource/lookup/prmy.go
@@ -23,9 +23,17 @@ var ReadPrmy = func(vers *string, name *string) (models.PackUnit, string, error)
 	for _, item = range list {
 		switch item {
 		case "updates-testing", "updates", "testing":
-			path = fmt.Sprintf("%s/%s", config.DBFOLDER, fmt.Sprintf("metasource-%s-%s-primary.sqlite", *vers, item))
+			path = fmt.Sprintf(
+				"%s/%s",
+				config.DBFOLDER,
+				fmt.Sprintf("metasource-%s-%s-primary.sqlite", *vers, item),
+			)
 		default:
-			path = fmt.Sprintf("%s/%s", config.DBFOLDER, fmt.Sprintf("metasource-%s-primary.sqlite", *vers))
+			path = fmt.Sprintf(
+				"%s/%s",
+				config.DBFOLDER,
+				fmt.Sprintf("metasource-%s-primary.sqlite", *vers),
+			)
 		}
 		_, expt = os.Stat(path)
 		if os.IsNotExist(expt) {
@@ -40,7 +48,21 @@ var ReadPrmy = func(vers *string, name *string) (models.PackUnit, string, error)
 		defer base.Close()
 
 		unit = base.QueryRow(config.OBTAIN_PACKAGE, name)
-		expt = unit.Scan(&rslt.Key, &rslt.Id, &rslt.Name, &rslt.Source, &rslt.Epoch, &rslt.Version, &rslt.Release, &rslt.Arch, &rslt.Summary, &rslt.Desc, &rslt.Link)
+		expt = unit.Scan(
+			&rslt.Key,
+			&rslt.Id,
+			&rslt.Name,
+			&rslt.Source,
+			&rslt.Epoch,
+			&rslt.Version,
+			&rslt.Release,
+			&rslt.Arch,
+			&rslt.Summary,
+			&rslt.Desc,
+			&rslt.Link,
+			&rslt.SizePackage,
+			&rslt.SizeInstalled,
+		)
 
 		if errors.Is(expt, sql.ErrNoRows) {
 			continue

--- a/metasource/lookup/rela.go
+++ b/metasource/lookup/rela.go
@@ -20,9 +20,17 @@ var ReadRelation = func(vers *string, pack *models.PackUnit, repo *string, relat
 
 	switch *repo {
 	case "updates-testing", "updates", "testing":
-		path = fmt.Sprintf("%s/%s", config.DBFOLDER, fmt.Sprintf("metasource-%s-%s-primary.sqlite", *vers, *repo))
+		path = fmt.Sprintf(
+			"%s/%s",
+			config.DBFOLDER,
+			fmt.Sprintf("metasource-%s-%s-primary.sqlite", *vers, *repo),
+		)
 	default:
-		path = fmt.Sprintf("%s/%s", config.DBFOLDER, fmt.Sprintf("metasource-%s-primary.sqlite", *vers))
+		path = fmt.Sprintf(
+			"%s/%s",
+			config.DBFOLDER,
+			fmt.Sprintf("metasource-%s-primary.sqlite", *vers),
+		)
 	}
 	_, expt = os.Stat(path)
 	if os.IsNotExist(expt) {
@@ -49,7 +57,21 @@ var ReadRelation = func(vers *string, pack *models.PackUnit, repo *string, relat
 	rslt = []models.PackUnit{}
 
 	for rows.Next() {
-		expt = rows.Scan(&pkit.Key, &pkit.Id, &pkit.Name, &pkit.Source, &pkit.Epoch, &pkit.Version, &pkit.Release, &pkit.Arch, &pkit.Summary, &pkit.Desc, &pkit.Link)
+		expt = rows.Scan(
+			&pkit.Key,
+			&pkit.Id,
+			&pkit.Name,
+			&pkit.Source,
+			&pkit.Epoch,
+			&pkit.Version,
+			&pkit.Release,
+			&pkit.Arch,
+			&pkit.Summary,
+			&pkit.Desc,
+			&pkit.Link,
+			&pkit.SizePackage,
+			&pkit.SizeInstalled,
+		)
 		if expt != nil {
 			return rslt, expt
 		}

--- a/metasource/lookup/rela.go
+++ b/metasource/lookup/rela.go
@@ -20,17 +20,9 @@ var ReadRelation = func(vers *string, pack *models.PackUnit, repo *string, relat
 
 	switch *repo {
 	case "updates-testing", "updates", "testing":
-		path = fmt.Sprintf(
-			"%s/%s",
-			config.DBFOLDER,
-			fmt.Sprintf("metasource-%s-%s-primary.sqlite", *vers, *repo),
-		)
+		path = fmt.Sprintf("%s/%s", config.DBFOLDER, fmt.Sprintf("metasource-%s-%s-primary.sqlite", *vers, *repo))
 	default:
-		path = fmt.Sprintf(
-			"%s/%s",
-			config.DBFOLDER,
-			fmt.Sprintf("metasource-%s-primary.sqlite", *vers),
-		)
+		path = fmt.Sprintf("%s/%s", config.DBFOLDER, fmt.Sprintf("metasource-%s-primary.sqlite", *vers))
 	}
 	_, expt = os.Stat(path)
 	if os.IsNotExist(expt) {

--- a/metasource/lookup/srce.go
+++ b/metasource/lookup/srce.go
@@ -57,7 +57,21 @@ var ReadSrce = func(vers *string, name *string) (models.PackUnit, string, error)
 
 		for rows.Next() {
 			var pack models.PackUnit
-			expt = rows.Scan(&pack.Key, &pack.Id, &pack.Name, &pack.Source, &pack.Epoch, &pack.Version, &pack.Release, &pack.Arch, &pack.Summary, &pack.Desc, &pack.Link)
+			expt = rows.Scan(
+				&pack.Key,
+				&pack.Id,
+				&pack.Name,
+				&pack.Source,
+				&pack.Epoch,
+				&pack.Version,
+				&pack.Release,
+				&pack.Arch,
+				&pack.Summary,
+				&pack.Desc,
+				&pack.Link,
+				&pack.SizePackage,
+				&pack.SizeInstalled,
+			)
 			if expt != nil {
 				return rslt, item, expt
 			}

--- a/metasource/models/dict.go
+++ b/metasource/models/dict.go
@@ -37,22 +37,24 @@ type UnitOther struct {
 }
 
 type UnitPrimary struct {
-	Epoch       string     `json:"epoch"`
-	Version     string     `json:"version"`
-	Release     string     `json:"release"`
-	Repo        string     `json:"repo"`
-	Arch        string     `json:"arch"`
-	Summary     string     `json:"summary"`
-	Description string     `json:"description"`
-	Basename    string     `json:"basename"`
-	URL         string     `json:"url"`
-	Supplements []UnitBase `json:"supplements"`
-	Recommends  []UnitBase `json:"recommends"`
-	Conflicts   []UnitBase `json:"conflicts"`
-	Obsoletes   []UnitBase `json:"obsoletes"`
-	Provides    []UnitBase `json:"provides"`
-	Requires    []UnitBase `json:"requires"`
-	Enhances    []UnitBase `json:"enhances"`
-	Suggests    []UnitBase `json:"suggests"`
-	CoPackages  []string   `json:"co-packages"`
+	Epoch         string     `json:"epoch"`
+	Version       string     `json:"version"`
+	Release       string     `json:"release"`
+	Repo          string     `json:"repo"`
+	Arch          string     `json:"arch"`
+	Summary       string     `json:"summary"`
+	Description   string     `json:"description"`
+	Basename      string     `json:"basename"`
+	URL           string     `json:"url"`
+	Supplements   []UnitBase `json:"supplements"`
+	Recommends    []UnitBase `json:"recommends"`
+	Conflicts     []UnitBase `json:"conflicts"`
+	Obsoletes     []UnitBase `json:"obsoletes"`
+	Provides      []UnitBase `json:"provides"`
+	Requires      []UnitBase `json:"requires"`
+	Enhances      []UnitBase `json:"enhances"`
+	Suggests      []UnitBase `json:"suggests"`
+	CoPackages    []string   `json:"co-packages"`
+	SizePackage   string     `json:"package-size"`
+	SizeInstalled string     `json:"installed-size"`
 }

--- a/metasource/models/home.go
+++ b/metasource/models/home.go
@@ -21,17 +21,19 @@ type FileUnit struct {
 }
 
 type PackUnit struct {
-	Key     int
-	Id      sql.NullString
-	Name    sql.NullString
-	Source  sql.NullString
-	Epoch   sql.NullString
-	Version sql.NullString
-	Release sql.NullString
-	Arch    sql.NullString
-	Summary sql.NullString
-	Desc    sql.NullString
-	Link    sql.NullString
+	Key           int
+	Id            sql.NullString
+	Name          sql.NullString
+	Source        sql.NullString
+	Epoch         sql.NullString
+	Version       sql.NullString
+	Release       sql.NullString
+	Arch          sql.NullString
+	Summary       sql.NullString
+	Desc          sql.NullString
+	Link          sql.NullString
+	SizeInstalled sql.NullString
+	SizePackage   sql.NullString
 }
 
 type DepsUnit struct {

--- a/metasource/routes/prmy.go
+++ b/metasource/routes/prmy.go
@@ -48,16 +48,18 @@ func RetrievePrmy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rslt = models.UnitPrimary{
-		Repo:        repo,
-		Arch:        pack.Arch.String,
-		Epoch:       pack.Epoch.String,
-		Version:     pack.Version.String,
-		Release:     pack.Release.String,
-		Summary:     pack.Summary.String,
-		Description: pack.Desc.String,
-		Basename:    pack.Name.String,
-		URL:         pack.Link.String,
-		CoPackages:  coop,
+		Repo:          repo,
+		Arch:          pack.Arch.String,
+		Epoch:         pack.Epoch.String,
+		Version:       pack.Version.String,
+		Release:       pack.Release.String,
+		Summary:       pack.Summary.String,
+		Description:   pack.Desc.String,
+		Basename:      pack.Name.String,
+		URL:           pack.Link.String,
+		SizePackage:   pack.SizePackage.String,
+		SizeInstalled: pack.SizeInstalled.String,
+		CoPackages:    coop,
 	}
 	if rslt.Repo == "" {
 		rslt.Repo = "release"

--- a/metasource/routes/rela.go
+++ b/metasource/routes/rela.go
@@ -68,16 +68,18 @@ func RetrieveRelation(w http.ResponseWriter, r *http.Request) {
 		}
 
 		pkit = models.UnitPrimary{
-			Repo:        repo,
-			Arch:        item.Arch.String,
-			Epoch:       item.Epoch.String,
-			Version:     item.Version.String,
-			Release:     item.Release.String,
-			Summary:     item.Summary.String,
-			Description: item.Desc.String,
-			Basename:    item.Name.String,
-			URL:         item.Link.String,
-			CoPackages:  coop,
+			Repo:          repo,
+			Arch:          item.Arch.String,
+			Epoch:         item.Epoch.String,
+			Version:       item.Version.String,
+			Release:       item.Release.String,
+			Summary:       item.Summary.String,
+			Description:   item.Desc.String,
+			Basename:      item.Name.String,
+			URL:           item.Link.String,
+			CoPackages:    coop,
+			SizePackage:   item.SizePackage.String,
+			SizeInstalled: item.SizeInstalled.String,
 		}
 		if pkit.Repo == "" {
 			pkit.Repo = "release"

--- a/metasource/routes/srce.go
+++ b/metasource/routes/srce.go
@@ -48,16 +48,18 @@ func RetrieveSrce(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rslt = models.UnitPrimary{
-		Repo:        repo,
-		Arch:        pack.Arch.String,
-		Epoch:       pack.Epoch.String,
-		Version:     pack.Version.String,
-		Release:     pack.Release.String,
-		Summary:     pack.Summary.String,
-		Description: pack.Desc.String,
-		Basename:    pack.Name.String,
-		URL:         pack.Link.String,
-		CoPackages:  coop,
+		Repo:          repo,
+		Arch:          pack.Arch.String,
+		Epoch:         pack.Epoch.String,
+		Version:       pack.Version.String,
+		Release:       pack.Release.String,
+		Summary:       pack.Summary.String,
+		Description:   pack.Desc.String,
+		Basename:      pack.Name.String,
+		URL:           pack.Link.String,
+		CoPackages:    coop,
+		SizePackage:   pack.SizePackage.String,
+		SizeInstalled: pack.SizeInstalled.String,
 	}
 	if rslt.Repo == "" {
 		rslt.Repo = "release"

--- a/test/lookup_prmy_test.go
+++ b/test/lookup_prmy_test.go
@@ -61,8 +61,8 @@ func TestReadPrmy_Failure_FaultyPlea(t *testing.T) {
 	_, _, expt := lookup.ReadPrmy(&vers, &name)
 	if expt == nil {
 		t.Errorf("Received nothing, Expected error")
-	} else if expt.Error() != "sql: expected 2 destination arguments in Scan, not 11" {
-		t.Errorf("Received '%s', Expected 'sql: expected 2 destination arguments in Scan, not 11'", expt.Error())
+	} else if expt.Error() != "sql: expected 2 destination arguments in Scan, not 13" {
+		t.Errorf("Received '%s', Expected 'sql: expected 2 destination arguments in Scan, not 13'", expt.Error())
 	}
 }
 

--- a/test/lookup_rela_test.go
+++ b/test/lookup_rela_test.go
@@ -77,7 +77,7 @@ func TestReadRela_Failure_FaultyPlea(t *testing.T) {
 	_, expt := lookup.ReadRelation(&vers_lookup_rela, &pack_lookup_rela, &repo_lookup_rela, &rela_lookup_rela)
 	if expt == nil {
 		t.Errorf("Received nothing, Expected error")
-	} else if expt.Error() != "sql: expected 2 destination arguments in Scan, not 11" {
-		t.Errorf("Received '%s', Expected 'sql: expected 2 destination arguments in Scan, not 11'", expt.Error())
+	} else if expt.Error() != "sql: expected 2 destination arguments in Scan, not 13" {
+		t.Errorf("Received '%s', Expected 'sql: expected 2 destination arguments in Scan, not 13'", expt.Error())
 	}
 }

--- a/test/lookup_srce_test.go
+++ b/test/lookup_srce_test.go
@@ -61,8 +61,8 @@ func TestReadSrce_Failure_FaultyPlea(t *testing.T) {
 	_, _, expt := lookup.ReadSrce(&vers, &name)
 	if expt == nil {
 		t.Errorf("Received nothing, Expected error")
-	} else if expt.Error() != "sql: expected 2 destination arguments in Scan, not 11" {
-		t.Errorf("Received '%s', Expected 'sql: expected 2 destination arguments in Scan, not 11'", expt.Error())
+	} else if expt.Error() != "sql: expected 2 destination arguments in Scan, not 13" {
+		t.Errorf("Received '%s', Expected 'sql: expected 2 destination arguments in Scan, not 13'", expt.Error())
 	}
 }
 


### PR DESCRIPTION
This merge requests will solve issue #403.
It adds the package-size and installed-size fields to JSON responses of the endpoints:

- /{vers}/pkg/{name}
- /{vers}/srcpkg/{name}
- /{vers}/{rela}/{name}

I also took the freedom of adding the "meta" file to the .gitignore. "meta" refers to the recommended name of the output binary of the project.

Some formatting was added to very long lines of code.